### PR TITLE
Fix type annotations for list in < 3.9

### DIFF
--- a/tests/cli.yaml
+++ b/tests/cli.yaml
@@ -7,7 +7,7 @@ default_context:
     homepage: ""
     license: "Apache - explicitly grants patent rights"
     version: "1.0.0"
-    min_python: "3.9"
+    min_python: "3.8"
     library: "y"
     cli: "y"
     service: "n"

--- a/{{cookiecutter.module_name}}/src/{{cookiecutter.module_name}}/{% if cookiecutter.cli == 'y' -%} cli.py {%- endif %}
+++ b/{{cookiecutter.module_name}}/src/{{cookiecutter.module_name}}/{% if cookiecutter.cli == 'y' -%} cli.py {%- endif %}
@@ -4,8 +4,8 @@ For more information about typer, read the excellent documentation at
 https://typer.tiangolo.com/
 """
 {% if cookiecutter.min_python | replace('3.', '') | int < 9 -%}
-from __future__ import annotations  # Required for list[] syntax in <3.9
-{% endif -%}
+from typing import List
+{%- endif %}
 
 import typer
 
@@ -15,7 +15,11 @@ app = typer.Typer()
 
 
 @app.command()
+{% if cookiecutter.min_python | replace('3.', '') | int < 9 -%}
+def add(number: List[float] = typer.Option([])) -> None:
+{%- else -%}
 def add(number: list[float] = typer.Option([])) -> None:
+{%- endif %}
     """Add numbers and print the sum."""
 
     typer.echo("Adding numbers")

--- a/{{cookiecutter.module_name}}/tests/{% if cookiecutter.cli == 'y' -%} test_cli.py {%- endif%}
+++ b/{{cookiecutter.module_name}}/tests/{% if cookiecutter.cli == 'y' -%} test_cli.py {%- endif%}
@@ -3,9 +3,6 @@
 There is an overlap between these tests and the one in test_lib, but these are
 more a placeholder for tests than an example of ideal test strategy.
 """
-{% if cookiecutter.min_python | replace('3.', '') | int < 9 %}
-from __future__ import annotations  # Required for list[] syntax in <3.9
-{%- endif %}
 import subprocess
 
 import pytest


### PR DESCRIPTION
Although `from __future__ import annotations` is a valid backport
according to PEP 585, it is not usable here since mypy does not
recognise it.

> Usefulness of this syntax before PEP 585 is limited as external
> tooling like Mypy does not recognize standard collections as generic.
https://www.python.org/dev/peps/pep-0585/#implementation