### PR TITLE
Improve dockerfile example

### DIFF
--- a/{{cookiecutter.module_name}}/{% if cookiecutter.service == 'y' -%} Dockerfile {%- endif %}
+++ b/{{cookiecutter.module_name}}/{% if cookiecutter.service == 'y' -%} Dockerfile {%- endif %}
@@ -23,7 +23,7 @@ COPY . .
 RUN pip3 install --no-cache-dir build
 
 # Build the library.
-RUN python3 -m build .
+RUN python3 -m build --wheel .
 
 ################################################################################
 # Start the runtime image.
@@ -36,12 +36,14 @@ RUN groupadd --gid 1000 --system {{ cookiecutter.module_name }} && \
     useradd --uid 1000 --system {{ cookiecutter.module_name }} -g {{ cookiecutter.module_name }} -s /sbin/nologin
 
 # Copy the wheel file from the builder
-COPY --chown=1000:1000 --from=builder /app/dist/{{ cookiecutter.module_name }}-{{ cookiecutter.version }}-py3-none-any.whl .
+COPY --chown=1000:1000 --from=builder /app/dist/ dist/
 
 # Install the library without dependencies, as we are using the compiled
 # dependencies in "requirements.txt" to pin all versions.
-RUN pip3 install --no-cache-dir --no-deps {{ cookiecutter.module_name }}-{{ cookiecutter.version }}-py3-none-any.whl \
-  && rm {{ cookiecutter.module_name }}-{{ cookiecutter.version }}-py3-none-any.whl
+# Use --no-index and --find-links to have pip look for the module/wheel file in
+# the local directory tree.
+RUN pip3 install --no-cache-dir --no-deps --no-index --find-links=dist {{cookiecutter.module_name }} \
+  && rm -rf dist/
 
 # Copy the compiled requirements and install them. See the two alternatives for
 # different type of packages.


### PR DESCRIPTION
- Use --find-links and --no-index to avoid having to specify the full
  path to the wheel when installing.
- Build only wheel as the sdist was not needed.