### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/test-cookiecutters.yml
+++ b/.github/workflows/test-cookiecutters.yml
@@ -2,9 +2,9 @@ name: Test cookiecutters
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/{{cookiecutter.module_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.module_name}}/.github/workflows/test.yml
@@ -4,9 +4,9 @@ name: Test package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   run-tests:

--- a/{{cookiecutter.module_name}}/.github/workflows/{% if cookiecutter.library == 'y' -%} test-build.yml {%- endif %}
+++ b/{{cookiecutter.module_name}}/.github/workflows/{% if cookiecutter.library == 'y' -%} test-build.yml {%- endif %}
@@ -3,9 +3,9 @@ name: Test packaging
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   deploy:


### PR DESCRIPTION
Let's follow the new standard of using "main" as the default branch name.