### PR TITLE
Improve Dockerfile generation so images are created with digest hash

### DIFF
--- a/.github/workflows/update-docker.yaml
+++ b/.github/workflows/update-docker.yaml
@@ -1,0 +1,44 @@
+name: Update Docker base image hashes
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+
+jobs:
+  update-docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run the update-docker script
+        run: |
+          python3 scripts/update-docker.py
+
+      - name: Configure the repository
+        run: |
+          git config user.name "Github actions bot"
+          git config user.email "<>"
+
+      - name: Create a branch, commit and push
+        run: |
+          git checkout -b "base-image-$(date --iso-8601=seconds)"
+          git commit cookiecutter.json -m "Update Docker base image references"
+          git push origin main
+          gh pr create --fill
+          gh pr merge --rebase --auto

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ A generated example can be found at https://github.com/vikahl/python-example
   package.
 - __module_name__: Project name, following specification in [PEP 508]. Will be
   suggested based on the project name.
-- __author__: Name of the project author. Added in package metadata
-    (pyproject.toml)
+- __author__: Name of the project author. Added in package metadata (pyproject.toml)
   and in some cases the license.
 - __email__: Email for the project author. Added in package metadata (pyproject.toml).
 - __homepage__: Homepage for the project. Added in package metadata (pyproject.toml).
@@ -45,6 +44,7 @@ A generated example can be found at https://github.com/vikahl/python-example
   entrypoint defined in pyproject.toml.
 - __service__: Toggle service functions, adds a dockerfile and instructions on
   compiled requirements.
+- __architecture__: Set the architecture for the Dockerfile.
 
 ## Linters and tools
 

--- a/config/python-example.yaml
+++ b/config/python-example.yaml
@@ -12,3 +12,4 @@ default_context:
     library: "y"
     cli: "y"
     service: "y"
+    architecture: "amd64"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,19 +1,45 @@
 {
-  "h": "]\nA reasonable modern Python project template.\n\n- __project_name__: Human friendly name for the project.\n- __description__: Short description of the project. Added to the README and\n  package.\n- __module_name__: Project name, following specification in [PEP 508]. Will be\n  suggested based on the project name.\n- __author__: Name of the project author. Added in package metadata (pyproject.toml)\n  and in some cases the license.\n- __email__: Email for the project author. Added in package metadata (pyproject.toml).\n- __homepage__: Homepage for the project. Added in package metadata (pyproject.toml).\n- __license__: Select a license for the project. Will add a trove classifier\n  (in pyproject.toml) and a license file. If another license is needed they can be\n  replaced later.\n- __version__: Initial version.\n- __min_python__: Minimum Python version that is supported. Tox will generate\n  test environments for all newer versions. Backported modules might be used\n  for older Python versions.\n- __library__: Toggle library functions, adds a Github workflow for uploading\n  to PyPi.\n- __cli__: Toggle cli functions, adds a basic cli (based on Typer) with\n  entrypoint defined in pyproject.toml.\n- __service__: Toggle service functions, adds a dockerfile and instructions on\n  compiled requirements.\n\n [Press enter to continue",
-
+  "h": "]\nA reasonable modern Python project template.\n\n- __project_name__: Human friendly name for the project.\n- __description__: Short description of the project. Added to the README and\n  package.\n- __module_name__: Project name, following specification in [PEP 508]. Will be\n  suggested based on the project name.\n- __author__: Name of the project author. Added in package metadata (pyproject.toml)\n  and in some cases the license.\n- __email__: Email for the project author. Added in package metadata (pyproject.toml).\n- __homepage__: Homepage for the project. Added in package metadata (pyproject.toml).\n- __license__: Select a license for the project. Will add a trove classifier\n  (in pyproject.toml) and a license file. If another license is needed they can be\n  replaced later.\n- __version__: Initial version.\n- __min_python__: Minimum Python version that is supported. Tox will generate\n  test environments for all newer versions. Backported modules might be used\n  for older Python versions.\n- __library__: Toggle library functions, adds a Github workflow for uploading\n  to PyPi.\n- __cli__: Toggle cli functions, adds a basic cli (based on Typer) with\n  entrypoint defined in pyproject.toml.\n- __service__: Toggle service functions, adds a dockerfile and instructions on\n  compiled requirements.\n- __architecture__: Set the architecture for the Dockerfile.\n\n [Press enter to continue",
   "project_name": "Python project template",
   "description": "",
   "module_name": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "author": "",
   "email": "",
   "homepage": "",
-  "license": ["MIT - simple and permissive",
+  "license": [
+    "MIT - simple and permissive",
     "Apache - explicitly grants patent rights",
-    "GPL - ensures that code based on this is shared with the same terms"],
+    "GPL - ensures that code based on this is shared with the same terms"
+  ],
   "version": "0.0.1",
   "min_python": "3.8",
-
-  "library": ["y", "n"],
-  "cli": ["n", "y"],
-  "service": ["n", "y"]
+  "library": [
+    "y",
+    "n"
+  ],
+  "cli": [
+    "n",
+    "y"
+  ],
+  "service": [
+    "n",
+    "y"
+  ],
+  "architecture": ["amd64", "arm64"],
+  "_base_images": {
+    "amd64": {
+      "3.10": "3.10-slim@sha256:1d517e04d033a04d86f7de57bf41cae166ca362b37a1cb229e326bc1d754db55",
+      "3.11": "3.11-slim@sha256:e932b9a0f25c306d542fc69133d24b872a6a264810e300b553e7ecd027599ca5",
+      "3.12": "3.12-slim@sha256:dc1395bbb3dd97d237f37f7fb324cd1801a40c82635e5b0100a057fb7cc2d227",
+      "3.8": "3.8-slim@sha256:f8a12edddd4fb9c9fd38cd7147c5861a596dee5a4852b6bded3d1d6e2c8987bd",
+      "3.9": "3.9-slim@sha256:e05be7fa5b887748df8b7ee9ee26201b4c20cf741cccae0393ee744c0b185401"
+    },
+    "arm64": {
+      "3.10": "3.10-slim@sha256:1d12eaa626fc3387d0e952eb6e7d3ab5f518f02bb75d14a3089ff4bef19970a1",
+      "3.11": "3.11-slim@sha256:c10d559a8bc6f2d7ae3b148b6819a5fb54ae871109fbc8c7947a1dbcc1c7f773",
+      "3.12": "3.12-slim@sha256:682ef9a76d792f5a1c6498a66039a5df688392134ceace2195339e806d08c058",
+      "3.8": "3.8-slim@sha256:5bbd3a73570e9f88f4de82965abb7700fa893c7050d28b46d65c19e20ca5aea1",
+      "3.9": "3.9-slim@sha256:abce435c53602940dc8f855d1954ac6820145ca42cff06c7d8dbde26bac0a8f9"
+    }
+  }
 }

--- a/scripts/update-docker.py
+++ b/scripts/update-docker.py
@@ -1,0 +1,39 @@
+"""Utility script for updating the Docker base image hashes in cookiecutter.json
+
+No error handling at all, but it is ok given the controlled environment in
+which it is run.
+"""
+
+import json
+import pathlib
+
+import requests
+
+
+def get_latest_hash(tag: str, architecture: str) -> str:
+    r = requests.get(
+        f"https://hub.docker.com/v2/repositories/library/python/tags/{tag}"
+    )
+
+    for image in r.json()["images"]:
+        if image["architecture"] == architecture:
+            return f"{tag}@{image['digest']}"
+
+    raise RuntimeError(f"No image found for {tag=} and {architecture=}")
+
+
+cookie_file = pathlib.Path(__file__).parent.parent / "cookiecutter.json"
+
+with open(cookie_file, "r+") as f:
+    cookie_tpl = json.load(f)
+
+    # Get latest hashes from Docker hub
+    for architecture, python_versions in cookie_tpl["_base_images"].items():
+        for python_version, digest in python_versions.items():
+            # Update the dict in place
+            python_versions[python_version] = get_latest_hash(
+                f"{python_version}-slim", architecture
+            )
+
+    f.seek(0)
+    json.dump(cookie_tpl, f, indent=2)

--- a/{{cookiecutter.module_name}}/.github/dependabot.yaml
+++ b/{{cookiecutter.module_name}}/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+    ignore:
+      # Ignore minor updates in images, e.g., do not update from 3.8 to 3.12.
+      # If you want this behaviour, simply remove this ignore rule.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor"]

--- a/{{cookiecutter.module_name}}/{% if cookiecutter.service == 'y' -%} Dockerfile {%- endif %}
+++ b/{{cookiecutter.module_name}}/{% if cookiecutter.service == 'y' -%} Dockerfile {%- endif %}
@@ -1,12 +1,15 @@
 # Example Docker image that uses a multistage build to first build the a
 # library of the service.
 
-FROM python:{{ cookiecutter.min_python }}-slim AS builder
+FROM python:{{ cookiecutter._base_images[cookiecutter.architecture][cookiecutter.min_python] }} AS builder
 # It is recommended to use sha256 hash to ensure exact version, as tags can be
-# moved. For example:
-# FROM python:3.8-slim@sha256:a7deebfd654d0158999e9ae9a78ce4a9c7090816a2d1600d254fef8b7fd74cac
-# The tag ("slim") is ignored when the hash ("sha256:…") is used but it makes
-# it easier for humans to read which image is used.
+# moved. The tag ("slim") is ignored by Docker when the hash ("sha256:…") is
+# used but it allows Dependabot to skip update across minor versions (e.g.,
+# update from 3.8 to 3.10) and makes it easier for humans to read which image
+# is used.
+#
+# If you want dependabot to update from e.g., 3.8 to 3.10, update the config in
+# .github/dependabot.yaml
 #
 # It is however hard to maintain and update this in the template, which is why
 # it specifies with tags.
@@ -27,9 +30,8 @@ RUN python3 -m build --wheel .
 
 ################################################################################
 # Start the runtime image.
-# It is recommended to use sha256 here as well (see comment at builder FROM
-# statement).
-FROM python:{{ cookiecutter.min_python }}-slim AS runtime
+# See the notes at builder FROM statement about sha256 hashes and automatic updates.
+FROM python:{{ cookiecutter._base_images[cookiecutter.architecture][cookiecutter.min_python] }} AS runtime
 
 # Create a user and group to not run everything as root.
 RUN groupadd --gid 1000 --system {{ cookiecutter.module_name }} && \
@@ -78,4 +80,3 @@ COPY --chown=1000:1000 src/run.py .
 
 # Run the service. This needs to be modified if the service is started with
 # another command (e.g., gunicorn).
-CMD python3 run.py


### PR DESCRIPTION
- Update template to reference images created by hash.
- Add workflow to automatically update Docker base images.
- Add dependabot config so that the generated template gets base image updates.
- Add support for different architectures in images.