### PR TITLE
Only commit in publish example if changes

### DIFF
--- a/.github/workflows/publish-example.yaml
+++ b/.github/workflows/publish-example.yaml
@@ -76,7 +76,8 @@ jobs:
         working-directory: .tmp/python-example-repo
         run: |
           git add .
-          git commit -m "Sync from vikahl/python-template $GITHUB_SHA"
+          # Only commit if there are changes
+          git diff-index --quiet HEAD || git commit -m "Sync from vikahl/python-template $GITHUB_SHA"
 
       - name: Commit (only on main builds)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Prevent the workflow from erroring out if there are no modified files.